### PR TITLE
Fix English grammar errors and Python format by Pylint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Split words apart.
 
 ### Output
 
-* word_split.text: splitted text.
+* word_split.text: split text.
 
 ## word_split_chapters.py
 
@@ -65,7 +65,7 @@ Split words apart in all chapters.
 
 ### Output
 
-* chapter_split(folder): splitted text.  One file for each chapter, numbered from "1.text".
+* chapter_split(folder): split text.  One file for each chapter, numbered from "1.text".
 
 ## word_count.py
 
@@ -73,19 +73,19 @@ Count words.
 
 ### Input
 
-* word_split.text: splitted text.
+* word_split.text: split text.
 
 ### Output
 
-* word_count.csv: counting result, sorted by number of occurence.
+* word_count.csv: counting result, sorted by number of occurrence.
 
 ## word_count_chapters.py
 
-Count words in each chapters.
+Count words in each chapter.
 
 ### Input
 
-* chapter_split(folder): splitted text for each chapter.
+* chapter_split(folder): split text for each chapter.
 
 ### Output
 
@@ -101,15 +101,15 @@ Do PCA analysis. Show result on screen.
 
 ### Input
 
-* word_count_chapters.csv: word counting result for each chapters.
+* word_count_chapters.csv: word counting result for each chapter.
 
 ### Output
 
-* components.csv: weights for each components.
+* components.csv: weights for each component.
 
 ## suffix_tree.py
 
-Libary for suffix tree.
+Library for suffix tree.
 
 ## correctness_calculate.py
 

--- a/analysis.py
+++ b/analysis.py
@@ -24,7 +24,7 @@ def main():
     data_frame = [list() for _ in range(number_of_chapters)]
     for word, counts in counter.items():
         # Filter features
-        normalized_variance = word_count_chapters.variance(counts)/(sum(counts)/number_of_chapters)
+        normalized_variance = word_count_chapters.variance(counts) / (sum(counts) / number_of_chapters)
         if normalized_variance > 0.85 or word in ignored_words:
             continue
 
@@ -65,7 +65,7 @@ def split_data(data_frame, prob=0.5):
     training_chapters = []
     for i, line in enumerate(data_frame):
         if adjust_prob:
-            adjusted_prob = prob/2 if i < 80 else prob
+            adjusted_prob = prob / 2 if i < 80 else prob
         else:
             adjusted_prob = prob
 
@@ -138,9 +138,10 @@ def plot_result(result):
         # plot.text(line[0], line[1], str(i+1), size=10, ha="center", va="center")
         # plot.scatter(line[0], line[1], marker=marker, c=color, s=200, linewidths=0)
 
-        plot.text(line[0], line[1], line[2], str(i+1), size=10, ha="center", va="center")
+        plot.text(line[0], line[1], line[2], str(i + 1), size=10, ha="center", va="center")
         plot.scatter(line[0], line[1], line[2], marker=marker, c=color, s=200, linewidths=0)
     plt.show()
+
 
 if __name__ == '__main__':
     main()

--- a/dict_creat.py
+++ b/dict_creat.py
@@ -34,7 +34,7 @@ def count_sentence_length(string):
     length = [len(string) for string in sentences]
     max_length = max(length)
 
-    count = [0]*(max_length+1)
+    count = [0] * (max_length + 1)
     for l in length:
         count[l] += 1
 
@@ -48,7 +48,7 @@ def count_all_possibilities(sentence_length_count, word_length):
     count_sum = 0
     for length, count in enumerate(sentence_length_count):
         if length >= word_length:
-            count_sum += count*(length - word_length + 1)
+            count_sum += count * (length - word_length + 1)
     return count_sum
 
 
@@ -65,13 +65,13 @@ def entropy_of_list(nodes):
     node_counts = [node.counter if str(node)[0] != split_mark else 1.
                    for node in nodes]
     count_sum = sum(node_counts)
-    probs = [count/count_sum for count in node_counts]
+    probs = [count / count_sum for count in node_counts]
 
-    entropy = -sum([prob*math.log(prob, 2) for prob in probs])
+    entropy = -sum([prob * math.log(prob, 2) for prob in probs])
 
     for node in nodes:
         if str(node)[0] == split_mark \
-              and node.counter >= 0.5 * count_sum + node.counter - 1:
+                and node.counter >= 0.5 * count_sum + node.counter - 1:
             return max(entropy, MIN_ENTROPY + 0.00001)
 
     return entropy
@@ -84,23 +84,23 @@ def mark_words(tree, reversed_tree, count_of_length, cursor, string):
     if cursor.current_node.counter >= MIN_COUNT:  # Filter by count
         if len(string) > 1:
             # Calculate co
-            p_no_split = cursor.current_node.counter/count_of_length[len(string)]
+            p_no_split = cursor.current_node.counter / count_of_length[len(string)]
 
             left_part = new_cursor(tree, string[0])
             right_part = copy.copy(cursor)
             right_part.move_front_forward(string[0])
             p_split = []
             for i in range(1, len(string)):
-                p_left = left_part.current_node.counter/count_of_length[i]
-                p_right = right_part.current_node.counter/count_of_length[len(string) - i]
-                p_split.append(p_left*p_right)
+                p_left = left_part.current_node.counter / count_of_length[i]
+                p_right = right_part.current_node.counter / count_of_length[len(string) - i]
+                p_split.append(p_left * p_right)
 
                 if i != len(string) - 1:
                     left_part.move_forward(string[i])
                     right_part.move_front_forward(string[i])
             # End of for i in range(1, len(string))
 
-            co = p_no_split/max(p_split)
+            co = p_no_split / max(p_split)
 
             if co >= MIN_CO:  # Filter by co
                 # Calculate entropy
@@ -112,11 +112,13 @@ def mark_words(tree, reversed_tree, count_of_length, cursor, string):
                 right_entropy = entropy_of_list(cursor.current_node.next.values())
 
                 # Calculate score
-                score = co*(left_entropy+right_entropy)
+                score = co * (left_entropy + right_entropy)
 
                 # Filter by score and entropy
                 if score > MIN_SCORE and left_entropy > MIN_ENTROPY and right_entropy > MIN_ENTROPY:
-                    output_file.write("%s,%d,%f,%f,%f,%f,%f\n" % (string, cursor.current_node.counter, co, left_entropy, right_entropy, left_entropy+right_entropy, score))
+                    output_file.write("%s,%d,%f,%f,%f,%f,%f\n" % (
+                    string, cursor.current_node.counter, co, left_entropy, right_entropy, left_entropy + right_entropy,
+                    score))
             # End of if co >= MIN_CO
         # End of if len(string) > 1
 
@@ -125,6 +127,8 @@ def mark_words(tree, reversed_tree, count_of_length, cursor, string):
             next_cursor = suffix_tree.Cursor(cursor.current_node, key, len(child), tree.root)
             mark_words(tree, reversed_tree, count_of_length, next_cursor, string + str(next_cursor.current_node))
     # End of if cursor.current_node.counter >= MIN_COUNT
+
+
 # End of def mark_words
 
 
@@ -141,7 +145,7 @@ def main():
                        for i in range(len(sentence_length_count))]
 
     print("Finding words")
-    process_update_interval = len(tree.root.next)//20
+    process_update_interval = len(tree.root.next) // 20
     for i, (key, child) in enumerate(tree.root.next.items()):
         if i % process_update_interval == 1:
             print("|", end="", flush=True)
@@ -149,6 +153,7 @@ def main():
         cursor = suffix_tree.Cursor(tree.root, key, len(child), tree.root)
         mark_words(tree, reversed_tree, count_of_length, cursor, str(cursor.current_node))
     print()
+
 
 if __name__ == "__main__":
     output_file = open("dict.csv", "w")

--- a/html_generate.py
+++ b/html_generate.py
@@ -94,7 +94,7 @@ scJsHost+
 "statcounter.com/counter/counter.js'></"+"script>");
 </script>
 <noscript><div class="statcounter"><a title="web analytics"
-href="http://statcounter.com/" target="_blank"><img
+href="https://statcounter.com/" target="_blank"><img
 class="statcounter"
 src="//c.statcounter.com/11426958/0/a175aef9/0/" alt="web
 analytics"></a></div></noscript>
@@ -111,6 +111,7 @@ def main():
     lines = sorted_table(load_data())
     output_index.write(apply_template(generate_index(lines)))
     output_expanded.write(apply_template(generate_expanded(lines)))
+
 
 if __name__ == '__main__':
     main()

--- a/preprocess.py
+++ b/preprocess.py
@@ -51,5 +51,6 @@ def main():
     string = input_file.read()
     output_file.write(preprocessing(string))
 
+
 if __name__ == "__main__":
     main()

--- a/preprocess_windows.py
+++ b/preprocess_windows.py
@@ -51,5 +51,6 @@ def main():
     string = input_file.read()
     output_file.write(preprocessing(string))
 
+
 if __name__ == "__main__":
     main()

--- a/word_count.py
+++ b/word_count.py
@@ -31,5 +31,6 @@ def main():
         if len(row[0]) > 1:
             output_file.write("%s,%d\n" % (row[0], row[1]))
 
+
 if __name__ == "__main__":
     main()

--- a/word_count_chapters.py
+++ b/word_count_chapters.py
@@ -12,12 +12,12 @@ def variance(array):
     """
     Calculate variance of a list of numbers.
     """
-    mean = sum(array)/len(array)
+    mean = sum(array) / len(array)
 
     result = 0
     for number in array:
-        result += abs(number - mean)**2
-    return math.sqrt(result/len(array))
+        result += abs(number - mean) ** 2
+    return math.sqrt(result / len(array))
 
 
 def count_word_for_chapter(counter, chapter_no, words):
@@ -26,10 +26,10 @@ def count_word_for_chapter(counter, chapter_no, words):
             continue
 
         if word in counter:
-            counter[word][chapter_no-1] += 1
+            counter[word][chapter_no - 1] += 1
         else:
-            counter[word] = [0]*number_of_chapters
-            counter[word][chapter_no-1] = 1
+            counter[word] = [0] * number_of_chapters
+            counter[word][chapter_no - 1] = 1
 
 
 def count_all_chapter():
@@ -59,13 +59,14 @@ def save_data(counter, output_file):
                 output_file.write("%d," % number)
 
             row_variance = variance(row[1])
-            output_file.write("%d,%f,%f\n" % (sum(row[1]), row_variance, row_variance/sum(row[1])))
+            output_file.write("%d,%f,%f\n" % (sum(row[1]), row_variance, row_variance / sum(row[1])))
 
 
 def main():
     output_file = open("word_count_chapters.csv", "w")
     counter = count_all_chapter()
     save_data(counter, output_file)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
1. splitted shoud never be used
No, splitted should never be used. The past tense and past participle of split is simply split. Say split.
https://www.englishforums.com/English/SplittedIsItCorrect/bbxlql/post.htm#:~:text=No%2C%20splitted%20should%20never%20be,Say%20split.

2. each chapters is wrong
We use each chapter to replace it, there are some similar errors.

3. python scripts format
PEP 8: E305 expected 2 blank lines after class or function definition, found 1